### PR TITLE
refactor: use `yaml_edit` for string handling 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,4 +31,4 @@ jobs:
         run: melos run lint:all
 
       - name: Run Tests
-        run: melos run test
+        run: melos run test:seq

--- a/packages/portico_auth_client/pubspec.yaml
+++ b/packages/portico_auth_client/pubspec.yaml
@@ -19,4 +19,4 @@ dependencies:
 dev_dependencies:
   lints: ^6.0.0
   mocktail: ^1.0.4
-  test: ^1.25.0
+  test: any

--- a/packages/portico_auth_credentials/pubspec.yaml
+++ b/packages/portico_auth_credentials/pubspec.yaml
@@ -17,5 +17,5 @@ dependencies:
 
 dev_dependencies:
   lints: ^6.0.0
-  test: ^1.25.0
+  test: any
   crypto: ^3.0.6

--- a/packages/portico_auth_roles/pubspec.yaml
+++ b/packages/portico_auth_roles/pubspec.yaml
@@ -19,4 +19,4 @@ dev_dependencies:
   build_runner: ^2.10.4
   json_serializable: ^6.9.0
   lints: ^6.0.0
-  test: ^1.25.0
+  test: any

--- a/packages/portico_auth_server_frog/pubspec.yaml
+++ b/packages/portico_auth_server_frog/pubspec.yaml
@@ -25,4 +25,4 @@ dev_dependencies:
   build_runner: ^2.4.8
   json_serializable: ^6.9.0
   mocktail: ^1.0.4
-  test: ^1.25.0
+  test: any

--- a/packages/portico_auth_server_frog/test/src/integration_test.dart
+++ b/packages/portico_auth_server_frog/test/src/integration_test.dart
@@ -12,6 +12,18 @@ class MockRequestContext extends Mock implements RequestContext {}
 
 class MockRequest extends Mock implements Request {}
 
+class FakeHashAdapter implements HashAdapter {
+  @override
+  Future<List<int>> hash(String password, List<int> salt) async {
+    return [...password.codeUnits, ...salt];
+  }
+
+  @override
+  Future<List<int>> salt() async {
+    return [1, 2, 3, 4];
+  }
+}
+
 void main() {
   group('AuthFrog Integration', () {
     late AuthTokensManager tokens;
@@ -33,6 +45,7 @@ void main() {
 
       credentials = AuthCredentialsManager(
         storage: AuthCredentialsInMemoryStorage(),
+        hasher: FakeHashAdapter(),
       );
       roles = AuthRoleManager(AuthRolesInMemoryStorage());
 

--- a/packages/portico_auth_server_shelf/pubspec.yaml
+++ b/packages/portico_auth_server_shelf/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   shelf: ^1.4.1
 
 dev_dependencies:
+  cryptography: ^2.9.0
   lints: ^6.0.0
   mocktail: ^1.0.4
   shelf_router: ^1.1.4

--- a/packages/portico_auth_server_shelf/pubspec.yaml
+++ b/packages/portico_auth_server_shelf/pubspec.yaml
@@ -21,4 +21,4 @@ dev_dependencies:
   lints: ^6.0.0
   mocktail: ^1.0.4
   shelf_router: ^1.1.4
-  test: ^1.25.0
+  test: any

--- a/packages/portico_auth_server_shelf/test/content_length_test.dart
+++ b/packages/portico_auth_server_shelf/test/content_length_test.dart
@@ -44,8 +44,7 @@ void main() {
         method,
         url,
         headers: {
-          if (contentLengthHeader != null)
-            'content-length': contentLengthHeader,
+          'content-length': ?contentLengthHeader,
           'content-type': 'application/json',
         },
       );

--- a/packages/portico_auth_server_shelf/test/login_test.dart
+++ b/packages/portico_auth_server_shelf/test/login_test.dart
@@ -7,6 +7,8 @@ import 'package:jose_plus/jose.dart';
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 
+import 'test_hasher.dart';
+
 const kIssuer = 'https://example.com';
 const kAudience = 'https://example.org';
 
@@ -48,7 +50,10 @@ void main() {
       audience: kAudience,
     );
     credentialStorage = AuthCredentialsInMemoryStorage();
-    credentials = AuthCredentialsManager(storage: credentialStorage);
+    credentials = AuthCredentialsManager(
+      storage: credentialStorage,
+      hasher: ArgonTestHash(),
+    );
 
     rolesStorage = AuthRolesInMemoryStorage();
     roleManager = AuthRoleManager(rolesStorage);

--- a/packages/portico_auth_server_shelf/test/portico_auth_server_shelf_test.dart
+++ b/packages/portico_auth_server_shelf/test/portico_auth_server_shelf_test.dart
@@ -11,6 +11,8 @@ import 'package:jose_plus/jose.dart';
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 
+import 'test_hasher.dart';
+
 const kIssuer = 'https://example.com';
 const kAudience = 'https://example.org';
 
@@ -49,7 +51,10 @@ void main() {
       audience: kAudience,
     );
     final credStorage = AuthCredentialsInMemoryStorage();
-    final credService = AuthCredentialsManager(storage: credStorage);
+    final credService = AuthCredentialsManager(
+      storage: credStorage,
+      hasher: ArgonTestHash(),
+    );
     await credService.registerUser('john@doe.net', 'password');
 
     rolesStorage = AuthRolesInMemoryStorage();

--- a/packages/portico_auth_server_shelf/test/registration_test.dart
+++ b/packages/portico_auth_server_shelf/test/registration_test.dart
@@ -7,6 +7,8 @@ import 'package:jose_plus/jose.dart';
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 
+import 'test_hasher.dart';
+
 const kIssuer = 'https://example.com';
 const kAudience = 'https://example.org';
 
@@ -47,7 +49,10 @@ void main() {
       audience: kAudience,
     );
     credentialStorage = AuthCredentialsInMemoryStorage();
-    credentials = AuthCredentialsManager(storage: credentialStorage);
+    credentials = AuthCredentialsManager(
+      storage: credentialStorage,
+      hasher: ArgonTestHash(),
+    );
 
     rolesStorage = AuthRolesInMemoryStorage();
     roleManager = AuthRoleManager(rolesStorage);

--- a/packages/portico_auth_server_shelf/test/test_hasher.dart
+++ b/packages/portico_auth_server_shelf/test/test_hasher.dart
@@ -1,0 +1,24 @@
+import 'package:cryptography/cryptography.dart' show Argon2id, SecretKeyData;
+import 'package:portico_auth_credentials/portico_auth_credentials.dart'
+    show HashAdapter;
+
+final class ArgonTestHash implements HashAdapter {
+  final Argon2id _argon2 = Argon2id(
+    parallelism: 1,
+    memory: 32,
+    iterations: 1,
+    hashLength: 32,
+  );
+
+  /// Generates a 16-byte random salt.
+  @override
+  Future<List<int>> salt() async => SecretKeyData.random(length: 16).bytes;
+
+  /// Hashes a [password] using Argon2id with the given [salt].
+  @override
+  Future<List<int>> hash(String password, List<int> salt) async =>
+      (await _argon2.deriveKeyFromPassword(
+        password: password,
+        nonce: salt,
+      )).extractBytes();
+}

--- a/packages/portico_auth_storage_sqlite/pubspec.yaml
+++ b/packages/portico_auth_storage_sqlite/pubspec.yaml
@@ -19,6 +19,5 @@ dependencies:
   sqflite_common_ffi: ^2.3.6
 
 dev_dependencies:
-
   lints: ^6.0.0
   test: any

--- a/packages/portico_auth_storage_sqlite/pubspec.yaml
+++ b/packages/portico_auth_storage_sqlite/pubspec.yaml
@@ -21,5 +21,4 @@ dependencies:
 dev_dependencies:
 
   lints: ^6.0.0
-
-  test: ^1.25.0
+  test: any

--- a/packages/portico_auth_storage_yaml/CHANGELOG.md
+++ b/packages/portico_auth_storage_yaml/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog
+
+## 1.0.1
+
+- Move to `yaml_edit` to handle strings better
+
 ## 1.0.0
 
 - Initial version.

--- a/packages/portico_auth_storage_yaml/lib/src/credentials_yaml.dart
+++ b/packages/portico_auth_storage_yaml/lib/src/credentials_yaml.dart
@@ -110,15 +110,10 @@ class AuthCredentialsYaml implements AuthCredentialsStorageAdapter {
   }
 
   void _save() {
-    final credentials = [
-      for (final cred in _credentials.values) cred.toJson(),
-    ];
+    final credentials = [for (final cred in _credentials.values) cred.toJson()];
 
     final yaml = YamlEditor('')
-      ..update([], {
-        'kind': 'user_credentials',
-        'credentials': credentials,
-      });
+      ..update([], {'kind': 'user_credentials', 'credentials': credentials});
     onYamlUpdate('$yaml');
   }
 }

--- a/packages/portico_auth_storage_yaml/lib/src/credentials_yaml.dart
+++ b/packages/portico_auth_storage_yaml/lib/src/credentials_yaml.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'package:portico_auth_credentials/portico_auth_credentials.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:yaml/yaml.dart';
+import 'package:yaml_edit/yaml_edit.dart';
 
 import 'extensions.dart';
 
@@ -109,19 +110,16 @@ class AuthCredentialsYaml implements AuthCredentialsStorageAdapter {
   }
 
   void _save() {
-    final credsYaml = [
-      for (var cred in _credentials.values)
-        [
-          for (final MapEntry(:key, :value) in cred.toJson().entries)
-            '$key: $value',
-        ].join('\n    '),
+    final credentials = [
+      for (final cred in _credentials.values) cred.toJson(),
     ];
 
-    onYamlUpdate('''
-kind: user_credentials
-credentials:
-${[for (final c in credsYaml) '  - $c'].join('\n')}
-''');
+    final yaml = YamlEditor('')
+      ..update([], {
+        'kind': 'user_credentials',
+        'credentials': credentials,
+      });
+    onYamlUpdate('$yaml');
   }
 }
 

--- a/packages/portico_auth_storage_yaml/lib/src/roles_yaml.dart
+++ b/packages/portico_auth_storage_yaml/lib/src/roles_yaml.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'package:portico_auth_roles/portico_auth_roles.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:yaml/yaml.dart';
+import 'package:yaml_edit/yaml_edit.dart';
 
 import 'extensions.dart';
 
@@ -139,29 +140,19 @@ class AuthRolesYaml implements AuthRolesStorageAdapter {
   }
 
   void _save() {
-    final rolesYaml = [
-      for (var role in _roles.values)
-        [
-          for (final MapEntry(:key, :value) in role.toJson().entries)
-            '$key: $value',
-        ].join('\n    '),
-    ];
-
+    final rolesYaml = [for (final role in _roles.values) role.toJson()];
     final assignmentsYaml = [
-      for (var assignment in _assignments.values)
-        [
-          for (final MapEntry(:key, :value) in assignment.toJson().entries)
-            '$key: $value',
-        ].join('\n    '),
+      for (final assignment in _assignments.values) assignment.toJson(),
     ];
 
-    onYamlUpdate('''
-kind: roles
-roles:
-${[for (final r in rolesYaml) '  - $r'].join('\n')}
-assignments:
-${[for (final a in assignmentsYaml) '  - $a'].join('\n')}
-''');
+    final yaml = YamlEditor('')
+      ..update([], {
+        'kind': 'roles',
+        'roles': rolesYaml,
+        'assignments': assignmentsYaml,
+      });
+    final yams = '$yaml';
+    onYamlUpdate(yams);
   }
 }
 

--- a/packages/portico_auth_storage_yaml/lib/src/roles_yaml.dart
+++ b/packages/portico_auth_storage_yaml/lib/src/roles_yaml.dart
@@ -151,8 +151,7 @@ class AuthRolesYaml implements AuthRolesStorageAdapter {
         'roles': rolesYaml,
         'assignments': assignmentsYaml,
       });
-    final yams = '$yaml';
-    onYamlUpdate(yams);
+    onYamlUpdate('$yaml');
   }
 }
 

--- a/packages/portico_auth_storage_yaml/lib/src/tokens_yaml.dart
+++ b/packages/portico_auth_storage_yaml/lib/src/tokens_yaml.dart
@@ -4,6 +4,7 @@ import 'package:portico_auth_tokens/portico_auth_tokens.dart'
     hide DateConverter;
 import 'package:yaml/yaml.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:yaml_edit/yaml_edit.dart';
 
 import 'extensions.dart';
 
@@ -108,19 +109,17 @@ class AuthTokensYaml implements AuthTokensStorageAdapter {
   }
 
   void _save() {
-    final creds = [
-      for (var cred in _memory.values)
-        [
-          for (final MapEntry(:key, :value) in cred.toJson().entries)
-            '$key: $value',
-        ].join('\n    '),
+    final credentials = [
+      for (final cred in _memory.values) cred.toJson(),
     ];
 
-    onYamlUpdate('''
-kind: ${YamlKind.credentials.name}
-credentials:
-${[for (final cred in creds) '  - $cred'].join('\n')}
-''');
+    final yaml = YamlEditor('')
+      ..update([], {
+        'kind': YamlKind.credentials.name,
+        'credentials': credentials,
+      });
+
+    onYamlUpdate('$yaml');
   }
 }
 

--- a/packages/portico_auth_storage_yaml/lib/src/tokens_yaml.dart
+++ b/packages/portico_auth_storage_yaml/lib/src/tokens_yaml.dart
@@ -109,9 +109,7 @@ class AuthTokensYaml implements AuthTokensStorageAdapter {
   }
 
   void _save() {
-    final credentials = [
-      for (final cred in _memory.values) cred.toJson(),
-    ];
+    final credentials = [for (final cred in _memory.values) cred.toJson()];
 
     final yaml = YamlEditor('')
       ..update([], {

--- a/packages/portico_auth_storage_yaml/pubspec.yaml
+++ b/packages/portico_auth_storage_yaml/pubspec.yaml
@@ -1,6 +1,7 @@
 name: portico_auth_storage_yaml
 resolution: workspace
-description: A file-based YAML storage backend for Portico Auth with automatic synchronization.
+description: A file-based YAML storage backend for Portico Auth with automatic
+  synchronization.
 version: 1.0.0
 repository: https://github.com/jtmcdole/portico_auth/tree/main/packages/portico_auth_storage_yaml
 issue_tracker: https://github.com/jtmcdole/portico_auth/issues
@@ -9,19 +10,20 @@ environment:
   sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
-  portico_auth_tokens: ^1.0.0
-  portico_auth_credentials: ^1.0.0
-  meta: ^1.16.0
-  yaml: ^3.1.3
-  json_annotation: ^4.9.0
-  equatable: ^2.0.7
-  portico_auth_roles: ^1.0.0
   crypto: ^3.0.7
+  equatable: ^2.0.7
+  json_annotation: ^4.9.0
+  meta: ^1.16.0
   path: ^1.9.1
+  portico_auth_credentials: ^1.0.0
+  portico_auth_roles: ^1.0.0
+  portico_auth_tokens: ^1.0.0
+  yaml: ^3.1.3
+  yaml_edit: ^2.2.4
 
 dev_dependencies:
-  lints: ^6.0.0
-  mocktail: ^1.0.4
-  test: ^1.25.0
   build_runner: ^2.4.8
   json_serializable: ^6.9.0
+  lints: ^6.0.0
+  mocktail: ^1.0.4
+  test: any

--- a/packages/portico_auth_storage_yaml/pubspec.yaml
+++ b/packages/portico_auth_storage_yaml/pubspec.yaml
@@ -2,7 +2,7 @@ name: portico_auth_storage_yaml
 resolution: workspace
 description: A file-based YAML storage backend for Portico Auth with automatic
   synchronization.
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/jtmcdole/portico_auth/tree/main/packages/portico_auth_storage_yaml
 issue_tracker: https://github.com/jtmcdole/portico_auth/issues
 

--- a/packages/portico_auth_storage_yaml/test/credentials_test.dart
+++ b/packages/portico_auth_storage_yaml/test/credentials_test.dart
@@ -162,7 +162,8 @@ credentials:
     String? capturedYaml;
     auth.onYamlUpdate = (yaml) => capturedYaml = yaml;
 
-    const maliciousId = 'user@example.com\n  - user_id: injected@example.com\n    salt: injected_salt\n    hash: injected_hash\n    creation_time: 2025-01-01T12:00:00.000';
+    const maliciousId =
+        'user@example.com\n  - user_id: injected@example.com\n    salt: injected_salt\n    hash: injected_hash\n    creation_time: 2025-01-01T12:00:00.000';
 
     await auth.createUser(
       userId: maliciousId,
@@ -173,7 +174,12 @@ credentials:
 
     expect(capturedYaml, isNotNull);
     // The malicious ID should be quoted and newlines escaped
-    expect(capturedYaml, contains('user_id: "user@example.com\\n  - user_id: injected@example.com\\n    salt: injected_salt\\n    hash: injected_hash\\n    creation_time: 2025-01-01T12:00:00.000"'));
+    expect(
+      capturedYaml,
+      contains(
+        'user_id: "user@example.com\\n  - user_id: injected@example.com\\n    salt: injected_salt\\n    hash: injected_hash\\n    creation_time: 2025-01-01T12:00:00.000"',
+      ),
+    );
 
     // Verify it parses back as a single user with the long malicious ID
     final auth2 = AuthCredentialsYaml(yaml: capturedYaml!);

--- a/packages/portico_auth_storage_yaml/test/credentials_test.dart
+++ b/packages/portico_auth_storage_yaml/test/credentials_test.dart
@@ -156,4 +156,34 @@ credentials:
       throwsA(isA<UserDoesNotExistException>()),
     );
   });
+
+  test('Prevents YAML injection via userId', () async {
+    final auth = AuthCredentialsYaml();
+    String? capturedYaml;
+    auth.onYamlUpdate = (yaml) => capturedYaml = yaml;
+
+    const maliciousId = 'user@example.com\n  - user_id: injected@example.com\n    salt: injected_salt\n    hash: injected_hash\n    creation_time: 2025-01-01T12:00:00.000';
+
+    await auth.createUser(
+      userId: maliciousId,
+      salt: 'normalsalt',
+      hash: 'normalhash',
+      creationTime: DateTime.parse('2025-01-01T12:00:00.000'),
+    );
+
+    expect(capturedYaml, isNotNull);
+    // The malicious ID should be quoted and newlines escaped
+    expect(capturedYaml, contains('user_id: "user@example.com\\n  - user_id: injected@example.com\\n    salt: injected_salt\\n    hash: injected_hash\\n    creation_time: 2025-01-01T12:00:00.000"'));
+
+    // Verify it parses back as a single user with the long malicious ID
+    final auth2 = AuthCredentialsYaml(yaml: capturedYaml!);
+    final cred = await auth2.getPasswordHash(maliciousId);
+    expect(cred.hash, 'normalhash');
+
+    // Verify the injected user DOES NOT exist
+    expect(
+      () => auth2.getPasswordHash('injected@example.com'),
+      throwsA(isA<UserDoesNotExistException>()),
+    );
+  });
 }

--- a/packages/portico_auth_storage_yaml/test/portico_auth_storage_yaml_io_test.dart
+++ b/packages/portico_auth_storage_yaml/test/portico_auth_storage_yaml_io_test.dart
@@ -73,7 +73,7 @@ credentials:
       // Wait for write
       await Future.delayed(Duration(milliseconds: 200));
       expect(await file.exists(), isTrue);
-      expect(await file.readAsString(), contains('serial: 456'));
+      expect(await file.readAsString(), contains('serial: "456"'));
 
       await adapter.stop();
     });

--- a/packages/portico_auth_storage_yaml/test/roles_test.dart
+++ b/packages/portico_auth_storage_yaml/test/roles_test.dart
@@ -193,4 +193,47 @@ roles:
     expect(roles.roles, isEmpty);
     expect(roles.assignments, isEmpty);
   });
+
+  test('Prevents YAML injection via role name and user ID', () async {
+    final auth = AuthRolesYaml();
+    String? capturedYaml;
+    auth.onYamlUpdate = (yaml) => capturedYaml = yaml;
+
+    const maliciousRoleName =
+        'admin\n  - name: injected_role\n    display_name: Injected\n    description: Injected\n    is_active: true';
+    const maliciousUserId = 'user@example.com\n    role_name: injected_role';
+
+    await auth.createRole(
+      const Role(
+        name: maliciousRoleName,
+        displayName: 'Normal',
+        description: 'Normal',
+      ),
+    );
+
+    await auth.assignRole(userId: maliciousUserId, roleName: maliciousRoleName);
+
+    print('capturedYaml: $capturedYaml');
+    expect(capturedYaml, isNotNull);
+    // Malicious strings should be quoted and escaped
+    expect(
+      capturedYaml,
+      contains('"${maliciousRoleName.replaceAll('\n', '\\n')}"'),
+    );
+    expect(
+      capturedYaml,
+      contains('"${maliciousUserId.replaceAll('\n', '\\n')}"'),
+    );
+
+    final auth2 = AuthRolesYaml(yaml: capturedYaml!);
+    final role = await auth2.getRole(maliciousRoleName);
+    expect(role, isNotNull);
+
+    // Verify injected role DOES NOT exist
+    expect(await auth2.getRole('injected_role'), isNull);
+
+    // Verify injected assignment DOES NOT exist
+    final assignments = await auth2.getUserAssignments('user@example.com');
+    expect(assignments, isEmpty);
+  });
 }

--- a/packages/portico_auth_storage_yaml/test/tokens_test.dart
+++ b/packages/portico_auth_storage_yaml/test/tokens_test.dart
@@ -146,4 +146,43 @@ credentials:
       isNot(contains('40ea03c0-12d6-41e9-bd75-22e006598795')),
     );
   });
+
+  test('Prevents YAML injection via serial and userId', () async {
+    final auth = AuthTokensYaml();
+    String? capturedYaml;
+    auth.onYamlUpdate = (yaml) => capturedYaml = yaml;
+
+    const maliciousSerial = 'serial1\n  - serial: injected_serial\n    user_id: injected@user.com\n    name: injected\n    initial_time: 2025-01-01T00:00:00.000\n    last_time: 2025-01-01T00:00:00.000\n    counter: 99';
+    const maliciousUserId = 'user1\n    counter: 100';
+
+    await auth.recordRefreshToken(
+      serial: maliciousSerial,
+      userId: maliciousUserId,
+      initial: DateTime.parse('2025-01-01T00:00:00.000'),
+      lastUpdate: DateTime.parse('2025-01-01T00:00:00.000'),
+      counter: 1,
+      name: 'normal name',
+    );
+
+    expect(capturedYaml, isNotNull);
+    // Malicious strings should be quoted and escaped
+    expect(capturedYaml, contains('serial: "serial1\\n  - serial: injected_serial\\n    user_id: injected@user.com\\n    name: injected\\n    initial_time: 2025-01-01T00:00:00.000\\n    last_time: 2025-01-01T00:00:00.000\\n    counter: 99"'));
+    expect(capturedYaml, contains('user_id: "user1\\n    counter: 100"'));
+
+    final auth2 = AuthTokensYaml(yaml: capturedYaml!);
+    final counters = await auth2.getRefreshTokenCounter(
+      serial: maliciousSerial,
+      userId: maliciousUserId,
+    );
+    expect(counters, [1]);
+
+    // Verify injected serial DOES NOT exist
+    expect(
+      await auth2.getRefreshTokenCounter(
+        serial: 'injected_serial',
+        userId: 'injected@user.com',
+      ),
+      [],
+    );
+  });
 }

--- a/packages/portico_auth_storage_yaml/test/tokens_test.dart
+++ b/packages/portico_auth_storage_yaml/test/tokens_test.dart
@@ -152,7 +152,8 @@ credentials:
     String? capturedYaml;
     auth.onYamlUpdate = (yaml) => capturedYaml = yaml;
 
-    const maliciousSerial = 'serial1\n  - serial: injected_serial\n    user_id: injected@user.com\n    name: injected\n    initial_time: 2025-01-01T00:00:00.000\n    last_time: 2025-01-01T00:00:00.000\n    counter: 99';
+    const maliciousSerial =
+        'serial1\n  - serial: injected_serial\n    user_id: injected@user.com\n    name: injected\n    initial_time: 2025-01-01T00:00:00.000\n    last_time: 2025-01-01T00:00:00.000\n    counter: 99';
     const maliciousUserId = 'user1\n    counter: 100';
 
     await auth.recordRefreshToken(
@@ -166,7 +167,12 @@ credentials:
 
     expect(capturedYaml, isNotNull);
     // Malicious strings should be quoted and escaped
-    expect(capturedYaml, contains('serial: "serial1\\n  - serial: injected_serial\\n    user_id: injected@user.com\\n    name: injected\\n    initial_time: 2025-01-01T00:00:00.000\\n    last_time: 2025-01-01T00:00:00.000\\n    counter: 99"'));
+    expect(
+      capturedYaml,
+      contains(
+        'serial: "serial1\\n  - serial: injected_serial\\n    user_id: injected@user.com\\n    name: injected\\n    initial_time: 2025-01-01T00:00:00.000\\n    last_time: 2025-01-01T00:00:00.000\\n    counter: 99"',
+      ),
+    );
     expect(capturedYaml, contains('user_id: "user1\\n    counter: 100"'));
 
     final auth2 = AuthTokensYaml(yaml: capturedYaml!);

--- a/packages/portico_auth_tokens/pubspec.yaml
+++ b/packages/portico_auth_tokens/pubspec.yaml
@@ -23,4 +23,4 @@ dev_dependencies:
   build_runner: ^2.10.4
   json_serializable: ^6.9.0
   lints: ^6.0.0
-  test: ^1.25.0
+  test: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,13 @@ melos:
         - melos exec --flutter --dir-exists test -- "flutter test"
       description: Run all tests in this project.
 
+    test:seq:
+      steps:
+        - melos exec -c 1 --no-flutter --dir-exists test -- "dart test"
+        - melos exec -c 1 --flutter --dir-exists test -- "flutter test"
+      description: Run all tests in this project; one at a time
+
+
     coverage:dart:collect:
       exec: dart run coverage:test_with_coverage
       packageFilters:


### PR DESCRIPTION
Uses `yaml_edit` to ensure strings are escaped.